### PR TITLE
[DPE-7152] Build on both bases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -29,7 +29,7 @@ jobs:
 
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,6 +4,7 @@
 type: charm
 platforms:
   ubuntu@22.04:amd64:
+  ubuntu@24.04:amd64:
 parts:
   charm:
     plugin: charm


### PR DESCRIPTION
Building on both 22 and 24 bases will enable the charm to work with Charmed Kafka tracks 3 and 4.